### PR TITLE
Add progress listener

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/ProgressListener.java
+++ b/src/main/java/qupath/ext/wsinfer/ProgressListener.java
@@ -1,0 +1,16 @@
+package qupath.ext.wsinfer;
+
+/**
+ * Minimal interface required for a progress listener when running inference.
+ */
+@FunctionalInterface
+public interface ProgressListener {
+
+    /**
+     * Report a progress update.
+     * @param message optional message to display
+     * @param progress optional progress value between 0 and 1. If null, only the message should be used.
+     */
+    void updateProgress(String message, Double progress);
+
+}

--- a/src/main/java/qupath/ext/wsinfer/ProgressLogger.java
+++ b/src/main/java/qupath/ext/wsinfer/ProgressLogger.java
@@ -1,0 +1,29 @@
+package qupath.ext.wsinfer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link ProgressListener} that sends progress messages to a logger.
+ */
+public class ProgressLogger implements ProgressListener {
+
+    private Logger logger;
+
+    public ProgressLogger(Logger logger) {
+        this.logger = logger == null ? LoggerFactory.getLogger(ProgressLogger.class) : logger;
+    }
+
+    @Override
+    public void updateProgress(String message, Double progress) {
+        if (message == null && progress == null)
+            return;
+        if (message == null)
+            logger.info("{}%", Math.round(progress * 100));
+        else if (progress == null)
+            logger.info(message);
+        else
+            logger.info("{}: {}%", message, Math.round(progress*100));
+    }
+
+}

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferProgressDialog.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferProgressDialog.java
@@ -1,0 +1,54 @@
+package qupath.ext.wsinfer.ui;
+
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.ProgressBar;
+import javafx.stage.Modality;
+import javafx.stage.Window;
+import qupath.ext.wsinfer.ProgressListener;
+
+/**
+ * Implementation of {@link ProgressListener} that shows a JavaFX progress dialog.
+ */
+class WSInferProgressDialog implements ProgressListener {
+
+    private Dialog<Void> dialog;
+    private ProgressBar progressBar = new ProgressBar();
+
+    public WSInferProgressDialog(Window owner, EventHandler<ActionEvent> cancelHandler) {
+        dialog = new Dialog<>();
+        dialog.initOwner(owner);
+        dialog.initModality(Modality.APPLICATION_MODAL);
+        dialog.getDialogPane().setPrefWidth(200);
+        dialog.setTitle("WSInfer");
+        dialog.getDialogPane().getButtonTypes().setAll(ButtonType.CANCEL);
+        dialog.getDialogPane().setContent(progressBar);
+        if (cancelHandler != null) {
+            var btnCancel = (Button)dialog.getDialogPane().lookupButton(ButtonType.CANCEL);
+            btnCancel.setOnAction(cancelHandler);
+        }
+    }
+
+
+    @Override
+    public void updateProgress(String message, Double progress) {
+        if (Platform.isFxApplicationThread()) {
+            if (message != null)
+                dialog.setHeaderText(message);
+            if (progress != null) {
+                progressBar.setProgress(progress);
+                if (progress.doubleValue() >= 1.0)
+                    dialog.hide();
+                else
+                    dialog.show();
+            }
+        } else {
+            Platform.runLater(() -> updateProgress(message, progress));
+        }
+    }
+
+}


### PR DESCRIPTION
Add progress listeners, which support logging or showing a JavaFX dialog.

LIngering problem: pressing cancel in the progress dialog just cancels without any problem. Using a Dialog seems problematic when attempting to show another 'child' dialog, since all my attempts to set the parent dialog to be the owner failed... and so the 'Stop all running tasks?' prompt always dropped behind the progress dialog itself.