### PR TITLE
Pete dev

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferCommand.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferCommand.java
@@ -18,7 +18,7 @@ import java.util.ResourceBundle;
  */
 public class WSInferCommand implements Runnable {
 
-    private static final Logger logger = LoggerFactory.getLogger(WSInferController.class);
+    private static final Logger logger = LoggerFactory.getLogger(WSInferCommand.class);
 
     private final QuPathGUI qupath;
 

--- a/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
+++ b/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
@@ -1,16 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
-<?import org.controlsfx.control.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.Slider?>
+<?import javafx.scene.control.Spinner?>
+<?import javafx.scene.control.SpinnerValueFactory.IntegerSpinnerValueFactory?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.control.ToggleButton?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Text?>
+<?import org.controlsfx.control.SegmentedButton?>
 
 <!--</BorderPane>-->
 
-<ScrollPane fitToHeight="true" fitToWidth="true" prefWidth="330" stylesheets="@wsinferstyles.css" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="qupath.ext.wsinfer.ui.WSInferController">
+<ScrollPane fitToHeight="true" fitToWidth="true" prefWidth="330" stylesheets="@wsinferstyles.css" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="qupath.ext.wsinfer.ui.WSInferController">
     <VBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
 <!--    Processing Pane************************************************************-->
-        <TitledPane fx:id="pane1" animated="false" text="%ui.processing.pane" VBox.vgrow="ALWAYS">
+        <TitledPane fx:id="pane1" animated="false" collapsible="false" text="%ui.processing.pane" VBox.vgrow="ALWAYS">
             <VBox alignment="TOP_CENTER" styleClass="standard-spacing ">
                 <children>
                     <!-- **********************Models**********************-->
@@ -42,8 +54,8 @@
                                       <Label styleClass="regular" text="%ui.selection.sub-label" />
                                        <SegmentedButton fx:id="segButton" maxWidth="500">
                                            <buttons>
-                                               <ToggleButton fx:id="selectAllAnnotations" text="%ui.selection.all-annotations" />
-                                               <ToggleButton fx:id="selectAllDetections" text="%ui.selection.all-detections" />
+                                               <ToggleButton fx:id="toggleSelectAllAnnotations" onAction="#selectAllAnnotations" text="%ui.selection.all-annotations" />
+                                               <ToggleButton fx:id="toggleSelectAllDetections" onAction="#selectAllTiles" text="%ui.selection.all-detections" />
                                            </buttons>
                                        </SegmentedButton>
                                    </children>
@@ -68,7 +80,7 @@
         </TitledPane>
 
 <!--    Results Pane************************************************************-->
-        <TitledPane fx:id="pane2" animated="false" text="%ui.results.pane" VBox.vgrow="ALWAYS">
+        <TitledPane fx:id="pane2" animated="false" collapsible="false" text="%ui.results.pane" VBox.vgrow="ALWAYS">
             <!--**********************Results**********************-->
             <VBox alignment="TOP_CENTER" styleClass="standard-spacing standard-padding">
                 <children>
@@ -77,7 +89,7 @@
                             <HBox alignment="CENTER" styleClass="standard-spacing">
                                 <children>
                                     <Button mnemonicParsing="false" onAction="#openMeasurementMaps" text="%ui.results.open-measurement-maps" />
-                                    <Button mnemonicParsing="false" onAction="#openMeasurementMaps" text="%ui.results.open-results" />
+                                    <Button mnemonicParsing="false" onAction="#openDetectionTable" text="%ui.results.open-results" />
                                 </children>
                             </HBox>
                             <HBox alignment="CENTER" styleClass="standard-spacing">
@@ -89,7 +101,7 @@
                             </HBox>
                             <VBox alignment="CENTER" styleClass="standard-spacing">
                                 <Label styleClass="regular" text="%ui.results.slider" />
-                                <Slider maxWidth="200.0" prefHeight="19.0" prefWidth="200.0" />
+                                <Slider fx:id="sliderOpacity" blockIncrement="0.1" majorTickUnit="0.1" max="1.0" maxWidth="200.0" minorTickCount="0" prefHeight="19.0" prefWidth="200.0" />
                             </VBox>
                         </children>
                     </VBox>
@@ -113,7 +125,7 @@
                     <VBox alignment="CENTER" styleClass="standard-spacing">
                         <children>
                             <Label styleClass="regular" text="%ui.hardware.directory" />
-                            <TextField fx:id="hardwareDirectory"/>
+                            <TextField fx:id="hardwareDirectory" />
                         </children>
                     </VBox>
                     <HBox alignment="CENTER" styleClass="standard-spacing">


### PR DESCRIPTION
* Simplify code for configuring toggle buttons
* Show detection tables
* Show (singleton) measurement map stage, where possible
* Select all annotations/tiles
  * Make toggle buttons act like regular buttons (by vetoing selections)
* Activate opacity slider
* Don't allow main title panes to be collapsed