### PR TITLE
Prompt to download PyTorch if needed

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
@@ -1,0 +1,118 @@
+package qupath.ext.wsinfer.ui;
+
+import ai.djl.engine.Engine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import qupath.lib.common.GeneralTools;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Helper class to manage access to PyTorch via Deep Java Library.
+ */
+class PytorchManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(PytorchManager.class);
+
+    /**
+     * Get the available devices for PyTorch, including MPS if Apple Silicon.
+     * @return
+     */
+    static Collection<String> getAvailableDevices() {
+        Set<String> availableDevices = new LinkedHashSet<>();
+        boolean includesMPS = false; // Don't add MPS twice
+        var engine = getEngineOffline();
+        if (engine != null) {
+            for (var device : engine.getDevices()) {
+                String name = device.getDeviceType();
+                availableDevices.add(name);
+                if (name.toLowerCase().startsWith("mps"))
+                    includesMPS = true;
+            }
+        }
+        // CPU should always be available
+        if (availableDevices.isEmpty())
+            availableDevices.add("cpu");
+
+        // If we could use MPS, but don't have it already, add it
+        if (!includesMPS && GeneralTools.isMac() && "aarch64".equals(System.getProperty("os.arch"))) {
+            availableDevices.add("mps");
+        }
+        return availableDevices;
+    }
+
+    /**
+     * Query if the PyTorch engine is already available, without a need to downlaod.
+     * @return
+     */
+    static boolean hasPyTorchEngine() {
+        return getEngineOffline() != null;
+    }
+
+    /**
+     * Get the PyTorch engine, without automatically downloading it if it isn't available.
+     * @return the engine if available, or null otherwise
+     */
+    static Engine getEngineOffline() {
+        try {
+            return callOffline(() -> Engine.getEngine("PyTorch"));
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Get the PyTorch engine, downloading if necessary.
+     * @return the engine if available, or null if this failed
+     */
+    static Engine getEngineOnline() {
+        try {
+            return callOnline(() -> Engine.getEngine("PyTorch"));
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Call a function with the "offline" property set to true (to block automatic downloads).
+     * @param callable
+     * @return
+     * @param <T>
+     * @throws Exception
+     */
+    private static <T> T callOffline(Callable<T> callable) throws Exception {
+        return callWithTempProperty("offline", "true", callable);
+    }
+
+    /**
+     * Call a function with the "offline" property set to false (to allow automatic downloads).
+     * @param callable
+     * @return
+     * @param <T>
+     * @throws Exception
+     */
+    private static <T> T callOnline(Callable<T> callable) throws Exception {
+        return callWithTempProperty("offline", "false", callable);
+    }
+
+
+    private static <T> T callWithTempProperty(String property, String value, Callable<T> callable) throws Exception {
+        String oldValue = System.getProperty(property);
+        System.setProperty(property, value);
+        try {
+            return callable.call();
+        } finally {
+            if (oldValue == null)
+                System.clearProperty(property);
+            else
+                System.setProperty(property, oldValue);
+        }
+    }
+
+
+}

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferController.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferController.java
@@ -1,6 +1,5 @@
 package qupath.ext.wsinfer.ui;
 
-import ai.djl.engine.Engine;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
@@ -33,7 +32,6 @@ import qupath.ext.wsinfer.WSInfer;
 import qupath.ext.wsinfer.models.WSInferModel;
 import qupath.ext.wsinfer.models.WSInferModelCollection;
 import qupath.ext.wsinfer.models.WSInferUtils;
-import qupath.lib.common.GeneralTools;
 import qupath.lib.common.ThreadTools;
 import qupath.lib.gui.QuPathGUI;
 import qupath.lib.gui.commands.Commands;
@@ -49,7 +47,6 @@ import qupath.lib.plugins.workflow.DefaultScriptableWorkflowStep;
 import java.awt.image.BufferedImage;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -102,7 +99,7 @@ public class WSInferController {
 
     private final ExecutorService pool = Executors.newSingleThreadExecutor(ThreadTools.createThreadFactory("wsinfer", true));
 
-    private final ObjectProperty<WSInferTask> pendingTask = new SimpleObjectProperty<>();
+    private final ObjectProperty<Task<?>> pendingTask = new SimpleObjectProperty<>();
 
 
     @FXML
@@ -163,7 +160,7 @@ public class WSInferController {
 
 
     private void configureAvailableDevices() {
-        var available = getAvailableDevices();
+        var available = PytorchManager.getAvailableDevices();
         deviceChoices.getItems().setAll(available);
         var selected = WSInferPrefs.deviceProperty().get();
         if (available.contains(selected))
@@ -178,26 +175,7 @@ public class WSInferController {
     }
 
 
-    private Collection<String> getAvailableDevices() {
-        Set<String> availableDevices = new LinkedHashSet<>();
-        boolean includesMPS = false; // Don't add MPS twice
-        try {
-            for (var device : Engine.getEngine("PyTorch").getDevices()) {
-                String name = device.getDeviceType();
-                availableDevices.add(name);
-                if (name.toLowerCase().startsWith("mps"))
-                    includesMPS = true;
-            }
-        } catch (Throwable e) {
-            logger.warn("PyTorch not found");
-            availableDevices.add("cpu");
-        }
-        // If we could use MPS, but don't have it already, add it
-        if (!includesMPS && GeneralTools.isMac() && "aarch64".equals(System.getProperty("os.arch"))) {
-            availableDevices.add("mps");
-        }
-        return availableDevices;
-    }
+
 
 
     private void configureRunInferenceButton() {
@@ -267,15 +245,21 @@ public class WSInferController {
      */
     public void runInference() {
         var imageData = this.imageDataProperty.get();
+        String title = resources.getString("title");
         if (imageData == null) {
-            Dialogs.showErrorMessage("WSInfer plugin", "Cannot run WSInfer plugin without ImageData.");
+            Dialogs.showErrorMessage(title, "Cannot run WSInfer plugin without ImageData.");
             return;
         }
-        var model = currentRunner.getModel();
-        submitInferenceTask(imageData, model.getName());
+        if (!PytorchManager.hasPyTorchEngine()) {
+            if (!Dialogs.showConfirmDialog(title, "PyTorch engine not found - would you like to download it?\nThis may take some time (but is only required once).")) {
+                Dialogs.showWarningNotification(title, "No inference performed - PyTorch engine not found.");
+                return;
+            }
+        }
+        submitInferenceTask(imageData);
     }
 
-    private void submitInferenceTask(ImageData<BufferedImage> imageData, String modelName) {
+    private void submitInferenceTask(ImageData<BufferedImage> imageData) {
         var task = new WSInferTask(imageData, currentRunner.getModel());
         pendingTask.set(task);
         // Reset the pending task when it completes (either successfully or not)
@@ -317,7 +301,7 @@ public class WSInferController {
     private void openMeasurementMaps(ActionEvent event) {
         // Try to use existing action, to avoid creating a new stage
         // TODO: Replace this if QuPath v0.5.0 provides direct access to the action
-        //       since that should be more robust
+        //       since that should be more robust (and also cope with language changes)
         var action = qupath.lookupActionByText("Show measurement maps");
         if (action != null) {
             action.handle(event);
@@ -351,7 +335,7 @@ public class WSInferController {
             this.imageData = imageData;
             this.model = model;
             this.progressListener = new WSInferProgressDialog(QuPathGUI.getInstance().getStage(), e -> {
-                if (Dialogs.showYesNoDialog("WSInfer", "Stop all running tasks?")) {
+                if (Dialogs.showYesNoDialog(getTitle(), "Stop all running tasks?")) {
                     cancel(true);
                     e.consume();
                 }
@@ -361,6 +345,12 @@ public class WSInferController {
         @Override
         protected Void call() throws Exception {
             try {
+                // Ensure PyTorch engine is available
+                if (!PytorchManager.hasPyTorchEngine()) {
+                    Platform.runLater(() -> Dialogs.showInfoNotification(getTitle(), "Downloading PyTorch engine..."));
+                    PytorchManager.getEngineOnline();
+                }
+                // Run inference
                 Platform.runLater(() -> Dialogs.showInfoNotification(getTitle(), "Requesting inference for " + model.getName()));
                 WSInfer.runInference(imageData, model, progressListener);
                 addToHistoryWorkflow(imageData, model.getName());


### PR DESCRIPTION
Avoids the need for the Deep Java Library extension - temporarily switches online/offline status as required, and downloads PyTorch automatically only if the user requests it.