### PR TITLE
Cache zoo file

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
+++ b/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
@@ -181,27 +181,21 @@ public class WSInferModel {
                 logger.error("Cannot create directory for model files {}", modelDirectory, e);
             }
         }
-        downloadFileToCacheDir("torchscript_model.pt");
-        downloadFileToCacheDir("config.json");
-        URL url = null;
         try {
-            url = new URL(String.format("https://huggingface.co/%s/raw/%s/torchscript_model.pt", hfRepoId, hfRevision));
-        } catch (MalformedURLException e) {
-            logger.error("Error downloading URL {}", url, e);
+            downloadFileToCacheDir("torchscript_model.pt");
+            downloadFileToCacheDir("config.json");
+            URL url = new URL(String.format("https://huggingface.co/%s/raw/%s/torchscript_model.pt", hfRepoId, hfRevision));
+            WSInferUtils.downloadURLToFile(url, getPointerFile());
+        } catch (IOException e) {
+            logger.error("Error downloading model files", e);
         }
-        WSInferUtils.downloadURLToFile(url, getPointerFile());
-        if (!isValid() && checkSHAMatches()) {
+        if (!isValid() || !checkSHAMatches()) {
             logger.error("Error downloading model");
         }
     }
 
-    private void downloadFileToCacheDir(String file) {
-        URL url;
-        try {
-            url = new URL(String.format("https://huggingface.co/%s/resolve/%s/%s", hfRepoId, hfRevision, file));
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
+    private void downloadFileToCacheDir(String file) throws IOException {
+        URL url = new URL(String.format("https://huggingface.co/%s/resolve/%s/%s", hfRepoId, hfRevision, file));
         WSInferUtils.downloadURLToFile(url, getFile(file));
     }
 }

--- a/src/main/java/qupath/ext/wsinfer/models/WSInferUtils.java
+++ b/src/main/java/qupath/ext/wsinfer/models/WSInferUtils.java
@@ -18,20 +18,18 @@ package qupath.ext.wsinfer.models;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import qupath.ext.wsinfer.ui.WSInferPrefs;
 import qupath.lib.io.GsonTools;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Objects;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Utility class to help with working with WSInfer models.
@@ -57,27 +55,6 @@ public class WSInferUtils {
         } catch (IOException e) {
             logger.error("Error downloading file {}", url, e);
         }
-    }
-
-    static String downloadJSON(URI uri) {
-        HttpRequest request = HttpRequest.newBuilder(uri)
-                .GET()
-                .build();
-        HttpResponse response = null;
-        try {
-            response = HttpClient.newHttpClient()
-                    .send(request, HttpResponse.BodyHandlers.ofString());
-        } catch (IOException | InterruptedException e) {
-            logger.error("Error in HTTP request for URI {}", uri, e);
-        }
-
-        int code = Objects.requireNonNull(response).statusCode();
-        if (code == 200) {
-            return (String) response.body();
-        } else if (code == 304) {
-            logger.error("Error code 304 downloading {}", uri);
-        }
-        return null;
     }
 
     /**
@@ -153,4 +130,5 @@ public class WSInferUtils {
         }
         return GsonTools.getInstance().fromJson(json, WSInferModelCollection.class);
     }
+
 }

--- a/src/main/resources/qupath/ext/wsinfer/ui/strings.properties
+++ b/src/main/resources/qupath/ext/wsinfer/ui/strings.properties
@@ -74,5 +74,5 @@ ui.pytorch-popup = No inference performed - PyTorch engine not found.
 ui.stop-tasks = Stop all running tasks?
 
 ##Errors
-error.window = Error initializing WSInfer window
+error.window = Error initializing WSInfer window.\nAn internet connection is required when running for the first time.
 error.no-imagedata = Cannot run WSInfer plugin without ImageData.


### PR DESCRIPTION
This first tries to download the zoo file, but if it's not present, it'll try to read a previously-download version. If all fails and we can't read the cached version, the error message at least should point people in the right direction.

I think this makes the extension as offline-friendly as possible.

Resolves #29 