### PR TITLE
ensure cpu is always an available device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1
+
+* Fix CPU/GPU support (https://github.com/qupath/qupath-extension-wsinfer/issues/41)
+
 ## v0.2.0
 
 * [Preprint on arXiv](https://arxiv.org/abs/2309.04631)

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 ext.moduleName = 'io.github.qupath.extension.wsinfer'
 
-version = "0.2.0"
+version = "0.2.1"
 description = 'An extension to run WSInfer in QuPath'
 
 // The default 'gradle.ext.qupathVersion' reads this from settings.gradle.

--- a/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
@@ -42,6 +42,7 @@ class PytorchManager {
         boolean includesMPS = false; // Don't add MPS twice
         var engine = getEngineOffline();
         if (engine != null) {
+            // This is expected to return GPUs if available, or CPU otherwise
             for (var device : engine.getDevices()) {
                 String name = device.getDeviceType();
                 availableDevices.add(name);

--- a/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/PytorchManager.java
@@ -50,7 +50,7 @@ class PytorchManager {
             }
         }
         // CPU should always be available
-        if (availableDevices.isEmpty())
+        if (!availableDevices.contains("cpu"))
             availableDevices.add("cpu");
 
         // If we could use MPS, but don't have it already, add it


### PR DESCRIPTION
`engine.getDevices()` lists either GPU devices or a single CPU device (if GPU is not available). this change ensures CPU is listed as well.

fixes #41 