### PR TITLE
Support custom batch sizes

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferController.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferController.java
@@ -126,6 +126,8 @@ public class WSInferController {
     @FXML
     private Spinner<Integer> spinnerNumWorkers;
     @FXML
+    private Spinner<Integer> spinnerBatchSize;
+    @FXML
     private TextField tfModelDirectory;
     @FXML
     private TextField localModelDirectory;
@@ -157,6 +159,7 @@ public class WSInferController {
         configureAvailableDevices();
         configureModelDirectory();
         configureNumWorkers();
+        configureBatchSize();
 
         configureMessageLabel();
         configureRunInferenceButton();
@@ -276,6 +279,10 @@ public class WSInferController {
 
     private void configureNumWorkers() {
         spinnerNumWorkers.getValueFactory().valueProperty().bindBidirectional(WSInferPrefs.numWorkersProperty());
+    }
+
+    private void configureBatchSize() {
+        spinnerBatchSize.getValueFactory().valueProperty().bindBidirectional(WSInferPrefs.batchSizeProperty());
     }
 
     /**
@@ -493,7 +500,7 @@ public class WSInferController {
 
         private final ImageData<BufferedImage> imageData;
         private final WSInferModel model;
-        private final ProgressListener progressListener;
+        private final WSInferProgressDialog progressListener;
 
         private WSInferTask(ImageData<BufferedImage> imageData, WSInferModel model) {
             this.imageData = imageData;
@@ -504,6 +511,12 @@ public class WSInferController {
                     e.consume();
                 }
             });
+            this.stateProperty().addListener(this::handleStateChange);
+        }
+
+        private void handleStateChange(ObservableValue<? extends Worker.State> value, Worker.State oldValue, Worker.State newValue) {
+            if (progressListener != null && newValue == Worker.State.CANCELLED)
+                progressListener.cancel();
         }
 
         private String getDialogTitle() {

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferPrefs.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferPrefs.java
@@ -41,8 +41,14 @@ public class WSInferPrefs {
 
     private static final Property<Integer> numWorkersProperty = PathPrefs.createPersistentPreference(
             "wsinfer.numWorkers",
-            1
+            Math.min(4, Runtime.getRuntime().availableProcessors())
     ).asObject();
+
+    private static final Property<Integer> batchSizeProperty = PathPrefs.createPersistentPreference(
+            "wsinfer.batchSize",
+            4
+    ).asObject();
+
     private static StringProperty localDirectoryProperty = PathPrefs.createPersistentPreference(
             "wsinfer.localDirectory",
             null);
@@ -66,6 +72,13 @@ public class WSInferPrefs {
      */
     public static Property<Integer> numWorkersProperty() {
         return numWorkersProperty;
+    }
+
+    /**
+     * Integer storing the batch size for inference.
+     */
+    public static Property<Integer> batchSizeProperty() {
+        return batchSizeProperty;
     }
 
     /**

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferProgressDialog.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferProgressDialog.java
@@ -52,6 +52,8 @@ class WSInferProgressDialog extends AnchorPane implements ProgressListener {
     @FXML
     private Button btnCancel;
 
+    private boolean isCancelled = false;
+
     public WSInferProgressDialog(Window owner, EventHandler<ActionEvent> cancelHandler) {
         URL url = getClass().getResource("progress_dialog.fxml");
         ResourceBundle resources = ResourceBundle.getBundle("qupath.ext.wsinfer.ui.strings");
@@ -76,6 +78,8 @@ class WSInferProgressDialog extends AnchorPane implements ProgressListener {
 
     @Override
     public void updateProgress(String message, Double progress) {
+        if (isCancelled)
+            return;
         if (Platform.isFxApplicationThread()) {
             if (message != null)
                 progressLabel.setText(message);
@@ -90,6 +94,17 @@ class WSInferProgressDialog extends AnchorPane implements ProgressListener {
         } else {
             Platform.runLater(() -> updateProgress(message, progress));
         }
+    }
+
+    /**
+     * Immediately cancel and hide the progress dialog.
+     * Subsequent calls to updateProgress will be ignored.
+     */
+    public void cancel() {
+        isCancelled = true;
+        stage.hide();
+        progressLabel.setText("Cancelled");
+        progressBar.setProgress(1.0);
     }
 
 }

--- a/src/main/resources/qupath/ext/wsinfer/ui/strings.properties
+++ b/src/main/resources/qupath/ext/wsinfer/ui/strings.properties
@@ -57,6 +57,8 @@ ui.options.localModelDirectory = User model directory:
 ui.options.localModelDirectory.tooltip = Choose the directory where user-created models can be loaded from
 ui.options.pworkers = Number of parallel tile loaders:
 ui.options.pworkers.tooltip = Choose the desired number of threads used to request tiles for inference
+ui.options.batchSize = Batch size:
+ui.options.batchSize.tooltip = Choose the batch size for inference
 
 # Model directories
 ui.model-directory.choose-directory = Choose directory
@@ -67,8 +69,8 @@ ui.model-directory.found-n-local-models = %d local models found
 ## Other Windows
 # Processing Window and progress pop-ups
 ui.processing = Processing tiles
-ui.processing-progress = Processing %d/%d tiles
-ui.processing-completed = Completed %d/%d tiles
+ui.processing-progress = Processing %d/%d tiles (%.1f per second)
+ui.processing-completed = Completed %d/%d tiles (%.1f per second)
 ui.cancel = Cancel
 ui.popup.fetching = Downloading model: %s
 ui.popup.available = Model available: %s

--- a/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
+++ b/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
@@ -150,7 +150,7 @@
     </TitledPane>
 
     <!--    Hardware Pane************************************************************-->
-    <TitledPane fx:id="pane3" animated="false" maxHeight="Infinity" text="%ui.options.pane" VBox.vgrow="NEVER">
+    <TitledPane fx:id="pane3" animated="false" expanded="false" maxHeight="Infinity" text="%ui.options.pane" VBox.vgrow="NEVER">
         <VBox alignment="TOP_CENTER" spacing="7.5" styleClass="standard-padding">
             <children>
                 <HBox alignment="CENTER" styleClass="standard-spacing">
@@ -163,13 +163,26 @@
                         </ChoiceBox>
                     </children>
                 </HBox>
+            <HBox alignment="CENTER" styleClass="standard-spacing">
+               <children>
+                  <Label styleClass="regular" text="%ui.options.batchSize" />
+                  <Spinner fx:id="spinnerBatchSize" prefWidth="75.0">
+                     <tooltip>
+                        <Tooltip text="%ui.options.batchSize.tooltip" />
+                     </tooltip>
+                     <valueFactory>
+                        <SpinnerValueFactory.IntegerSpinnerValueFactory initialValue="1" max="512" min="1" />
+                     </valueFactory>
+                  </Spinner>
+               </children>
+            </HBox>
                 <HBox alignment="CENTER" styleClass="standard-spacing">
                     <children>
                         <Label styleClass="regular" text="%ui.options.pworkers" />
                         <Spinner fx:id="spinnerNumWorkers" prefWidth="75.0">
                             <tooltip><Tooltip text="%ui.options.pworkers.tooltip" /></tooltip>
                             <valueFactory>
-                                <SpinnerValueFactory.IntegerSpinnerValueFactory initialValue="1" max="8" min="1" />
+                                <SpinnerValueFactory.IntegerSpinnerValueFactory initialValue="1" max="128" min="1" />
                             </valueFactory>
                         </Spinner>
                     </children>
@@ -178,7 +191,7 @@
                 <VBox alignment="CENTER" styleClass="standard-spacing">
                     <VBox alignment="CENTER" styleClass="standard-spacing">
                         <children>
-                            <Label styleClass="regular" text="%ui.options.directory"  labelFor="$tfModelDirectory" />
+                            <Label styleClass="regular" text="%ui.options.directory" />
                             <HBox styleClass="standard-spacing">
                                 <children>
                                     <TextField fx:id="tfModelDirectory" HBox.hgrow="ALWAYS">
@@ -200,7 +213,7 @@
                     </VBox>
                     <VBox alignment="CENTER" styleClass="standard-spacing">
                         <children>
-                            <Label styleClass="regular" text="%ui.options.localModelDirectory" labelFor="$localModelDirectory" />
+                            <Label styleClass="regular" text="%ui.options.localModelDirectory" />
                             <HBox styleClass="standard-spacing">
                                 <children>
                                     <TextField fx:id="localModelDirectory" HBox.hgrow="ALWAYS">


### PR DESCRIPTION
Now works on Apple Silicon / MPS!

Choosing a good batch size & number of tile workers can cut processing time by >50%.

Also show tiles per second in progress dialog, to make tuning parameters easier.