### PR TITLE
Use single model directory

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/models/WSInferUtils.java
+++ b/src/main/java/qupath/ext/wsinfer/models/WSInferUtils.java
@@ -32,6 +32,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.ResourceBundle;
 
@@ -66,15 +67,20 @@ public class WSInferUtils {
                     cachedModelCollection = downloadModelCollection();
             }
         }
-        String localModelDirectory = WSInferPrefs.localDirectoryProperty().get();
-        if (localModelDirectory != null) {
-            addLocalModels(cachedModelCollection, localModelDirectory);
+        String pathModels = WSInferPrefs.modelDirectoryProperty().get();
+        if (pathModels != null) {
+            File dirModels = new File(pathModels);
+            if (dirModels.isDirectory()) {
+                // Search for local models in 'local' or 'user' subdirectories
+                for (var name : Arrays.asList("local", "user")) {
+                    addLocalModels(cachedModelCollection, new File(dirModels, name));
+                }
+            }
         }
         return cachedModelCollection;
     }
 
-    private static void addLocalModels(WSInferModelCollection cachedModelCollection, String localModelDirectory) {
-        File modelDir = new File(localModelDirectory);
+    private static void addLocalModels(WSInferModelCollection cachedModelCollection, File modelDir) {
         if (!modelDir.exists() || !modelDir.isDirectory()) {
             return;
         }

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferCommand.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferCommand.java
@@ -44,6 +44,7 @@ public class WSInferCommand implements Runnable {
     private final ResourceBundle resources = ResourceBundle.getBundle("qupath.ext.wsinfer.ui.strings");
 
     private Stage stage;
+    private WSInferController controller;
 
     public WSInferCommand(QuPathGUI qupath) {
         this.qupath = qupath;
@@ -62,8 +63,10 @@ public class WSInferCommand implements Runnable {
                 logger.error(e.getMessage(), e);
                 return;
             }
-        } else
+        } else {
+            controller.refreshAvailableModels();
             stage.show();
+        }
     }
 
     private Stage createStage() throws IOException {
@@ -77,6 +80,7 @@ public class WSInferCommand implements Runnable {
         var loader = new FXMLLoader(url, resources);
         loader.setClassLoader(this.getClass().getClassLoader());
         VBox root = loader.load();
+        controller = loader.getController();
 
         // There's probably a better approach... but wrapping in a border pane
         // helped me get the resizing to behave

--- a/src/main/java/qupath/ext/wsinfer/ui/WSInferPrefs.java
+++ b/src/main/java/qupath/ext/wsinfer/ui/WSInferPrefs.java
@@ -49,10 +49,6 @@ public class WSInferPrefs {
             4
     ).asObject();
 
-    private static StringProperty localDirectoryProperty = PathPrefs.createPersistentPreference(
-            "wsinfer.localDirectory",
-            null);
-
     /**
      * String storing the preferred directory to cache models.
      */
@@ -79,13 +75,6 @@ public class WSInferPrefs {
      */
     public static Property<Integer> batchSizeProperty() {
         return batchSizeProperty;
-    }
-
-    /**
-     * String storing the preferred directory for user-supplied model folders.
-     */
-    public static StringProperty localDirectoryProperty() {
-        return localDirectoryProperty;
     }
 
     private static Path getUserDir() {

--- a/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
+++ b/src/main/resources/qupath/ext/wsinfer/ui/wsinfer_control.fxml
@@ -80,10 +80,10 @@
                                     </SegmentedButton>
                                 </children>
                             </HBox>
-                            <styleClass>
-                                <String fx:value="standard-spacing" />
-                                <String fx:value="standard-padding" />
-                            </styleClass>
+                     <styleClass>
+                        <String fx:value="standard-padding" />
+                        <String fx:value="standard-vertical-spacing" />
+                     </styleClass>
                         </VBox>
                     </children>
                 </VBox>
@@ -100,7 +100,7 @@
                     </HBox>
                     <Label id="labelWarning" fx:id="labelMessage" styleClass="error-message" text="%ui.error.no-selection" VBox.vgrow="ALWAYS" />
                     <styleClass>
-                        <String fx:value="standard-spacing" />
+                        <String fx:value="standard-vertical-spacing" />
                         <String fx:value="standard-padding" />
                     </styleClass>
                 </VBox>
@@ -113,7 +113,7 @@
         <!--**********************Results**********************-->
         <VBox alignment="TOP_CENTER" styleClass="standard-spacing standard-padding">
             <children>
-                <VBox alignment="CENTER" styleClass="standard-spacing">
+                <VBox alignment="CENTER" styleClass="standard-vertical-spacing">
                     <children>
                         <HBox alignment="CENTER" styleClass="standard-spacing">
                             <children>
@@ -150,7 +150,7 @@
     </TitledPane>
 
     <!--    Hardware Pane************************************************************-->
-    <TitledPane fx:id="pane3" animated="false" expanded="false" maxHeight="Infinity" text="%ui.options.pane" VBox.vgrow="NEVER">
+    <TitledPane fx:id="pane3" animated="false" maxHeight="Infinity" text="%ui.options.pane" VBox.vgrow="NEVER">
         <VBox alignment="TOP_CENTER" spacing="7.5" styleClass="standard-padding">
             <children>
                 <HBox alignment="CENTER" styleClass="standard-spacing">
@@ -163,7 +163,7 @@
                         </ChoiceBox>
                     </children>
                 </HBox>
-            <HBox alignment="CENTER" styleClass="standard-spacing">
+            <HBox alignment="CENTER">
                <children>
                   <Label styleClass="regular" text="%ui.options.batchSize" />
                   <Spinner fx:id="spinnerBatchSize" prefWidth="75.0">
@@ -175,6 +175,10 @@
                      </valueFactory>
                   </Spinner>
                </children>
+               <styleClass>
+                  <String fx:value="standard-vertical-spacing" />
+                  <String fx:value="standard-padding" />
+               </styleClass>
             </HBox>
                 <HBox alignment="CENTER" styleClass="standard-spacing">
                     <children>
@@ -189,9 +193,9 @@
                 </HBox>
                 <Separator prefWidth="200.0" />
                 <VBox alignment="CENTER" styleClass="standard-spacing">
-                    <VBox alignment="CENTER" styleClass="standard-spacing">
+                    <VBox alignment="CENTER" styleClass="standard-vertical-spacing">
                         <children>
-                            <Label styleClass="regular" text="%ui.options.directory" />
+                            <Label onMouseClicked="#handleModelDirectoryLabelClick" styleClass="regular" text="%ui.options.directory" />
                             <HBox styleClass="standard-spacing">
                                 <children>
                                     <TextField fx:id="tfModelDirectory" HBox.hgrow="ALWAYS">
@@ -213,24 +217,7 @@
                     </VBox>
                     <VBox alignment="CENTER" styleClass="standard-spacing">
                         <children>
-                            <Label styleClass="regular" text="%ui.options.localModelDirectory" />
-                            <HBox styleClass="standard-spacing">
-                                <children>
-                                    <TextField fx:id="localModelDirectory" HBox.hgrow="ALWAYS">
-                                        <tooltip>
-                                            <Tooltip text="%ui.options.localModelDirectory.tooltip" />
-                                        </tooltip>
-                                    </TextField>
-                                    <Button fx:id="userModelDirButton" mnemonicParsing="false" onAction="#promptForLocalModelDirectory">
-                                        <tooltip>
-                                            <Tooltip text="%ui.options.localModelDirectory.tooltip" />
-                                        </tooltip>
-                                        <graphic>
-                                            <Text styleClass="fa-icon" text="" />
-                                        </graphic>
-                                    </Button>
-                                </children>
-                            </HBox>
+                            <HBox styleClass="standard-spacing" />
                         </children>
                     </VBox>
                 </VBox>

--- a/src/main/resources/qupath/ext/wsinfer/ui/wsinferstyles.css
+++ b/src/main/resources/qupath/ext/wsinfer/ui/wsinferstyles.css
@@ -36,6 +36,11 @@
   -fx-spacing: 7.5;
 }
 
+/* spacing - current use in VBox*/
+.standard-vertical-spacing {
+  -fx-spacing: 5;
+}
+
 .standard-padding {
   -fx-padding: 2;
 }


### PR DESCRIPTION
Store local models inside a subdirectory of the model directory called either 'local' or 'user' (or both). This reduces the number of required preferences & also the vertical space required by the dialog (which can be important for small laptop monitors).