### PR TITLE
Pad SHA256 checksums with leading zeros if needed

### DIFF
--- a/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
+++ b/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
@@ -165,7 +165,7 @@ public class WSInferModel {
         }
         return null;
     }
- 
+
     private static String checkSumSHA256(File file) throws IOException, NoSuchAlgorithmException {
         byte[] data = Files.readAllBytes(file.toPath());
         byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);

--- a/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
+++ b/src/main/java/qupath/ext/wsinfer/models/WSInferModel.java
@@ -165,12 +165,18 @@ public class WSInferModel {
         }
         return null;
     }
-
+ 
     private static String checkSumSHA256(File file) throws IOException, NoSuchAlgorithmException {
         byte[] data = Files.readAllBytes(file.toPath());
         byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
-        return new BigInteger(1, hash).toString(16);
+        StringBuilder hexString = new StringBuilder(new BigInteger(1, hash).toString(16));
+
+        while (hexString.length() < 64) {
+            hexString.insert(0, '0');
+        }
+        return hexString.toString();
     }
+
 
     /**
      * Check that the SHA-256 checksum in the LFS pointer file matches one


### PR DESCRIPTION
This can lead to a SHA mismatch, because the LFS pointers have zero-padding